### PR TITLE
Fix syntax error, unexpected ','

### DIFF
--- a/lib/ropt/antagonistic_games/matrix_game.rb
+++ b/lib/ropt/antagonistic_games/matrix_game.rb
@@ -24,8 +24,8 @@ module Ropt
         {
           first_gamer_optimal_strategy: opt_strategy(:first),
           second_gamer_optimal_strategy: opt_strategy(:second),
-          lower_value:,
-          higher_value:,
+          lower_value: lower_value,
+          higher_value: higher_value,
           equilibrium: lower_value == higher_value
         }
       end


### PR DESCRIPTION
When `require 'ropt'` I got:
```
/var/lib/gems/3.0.0/gems/ropt-1.0.0/lib/ropt.rb:10:in `require_relative': /var/lib/gems/3.0.0/gems/ropt-1.0.0/lib/ropt/antagonistic_games/matrix_game.rb:27: syntax error, unexpected ',' (SyntaxError)
          lower_value:,
                      ^
```

This PR inserts a call to `lower_value` and `higher_value` on lines 27 & 28, so the error doesn't happen anymore and tests pass.
